### PR TITLE
Fix dynamic page parameter types

### DIFF
--- a/app/(site)/[slug]/page.tsx
+++ b/app/(site)/[slug]/page.tsx
@@ -1,12 +1,9 @@
 import { getPage } from "@/sanity/sanity-utils";
 import { PortableText } from "@portabletext/react";
 
-type Props = {
-  params: { slug: string }
-}
-
-export default async function Page({ params }: Props) {
-  const page = await getPage(params.slug);
+export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const page = await getPage(slug);
 
   return (
     <div><h1 className="bg-gradient-to-r from-orange-400 via-red-500 to-purple-600 bg-clip-text text-transparent text-5xl drop-shadow font-extrabold">{page.title}</h1>

--- a/app/(site)/projects/[project]/page.tsx
+++ b/app/(site)/projects/[project]/page.tsx
@@ -2,15 +2,9 @@ import { getProject } from "@/sanity/sanity-utils";
 import { PortableText } from "@portabletext/react";
 import Image from "next/image";
 
-type Props = {
-    params: {
-        project: string;
-    };
-};
+export default async function Project({ params }: { params: Promise<{ project: string }> }) {
 
-export default async function Project({ params }: Props) {
-
-    const slug = params.project;
+    const { project: slug } = await params;
 
     const project = await getProject(slug);
     


### PR DESCRIPTION
## Summary
- adjust parameter types in dynamic pages to match Next.js `PageProps`

## Testing
- `npm run build` *(fails: fetch failed during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68587f30f0a083279fa966cd8f241dca